### PR TITLE
Auto-enable dbsearch plugin

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -498,6 +498,7 @@ async function enableDefaultPlugins() {
         'nodebb-rewards-essentials',
         'nodebb-plugin-emoji',
         'nodebb-plugin-emoji-android',
+        'nodebb-plugin-dbsearch'
     ];
     let customDefaults = nconf.get('defaultplugins') || nconf.get('defaultPlugins');
 

--- a/src/install.js
+++ b/src/install.js
@@ -487,9 +487,11 @@ async function createWelcomePost() {
     }
 }
 
+
 async function enableDefaultPlugins() {
     console.log('Enabling default plugins');
 
+    //Type: string[]
     let defaultEnabled = [
         'nodebb-plugin-composer-default',
         'nodebb-plugin-markdown',
@@ -500,8 +502,11 @@ async function enableDefaultPlugins() {
         'nodebb-plugin-emoji-android',
         'nodebb-plugin-dbsearch',
     ];
+
+    //Type: string[].
     let customDefaults = nconf.get('defaultplugins') || nconf.get('defaultPlugins');
 
+    //Type: none.
     winston.info(`[install/defaultPlugins] customDefaults ${String(customDefaults)}`);
 
     if (customDefaults && customDefaults.length) {
@@ -518,8 +523,13 @@ async function enableDefaultPlugins() {
 
     winston.info('[install/enableDefaultPlugins] activating default plugins', defaultEnabled);
 
+    //Type: any
     const db = require('./database');
+
+    //Type: number[]
     const order = defaultEnabled.map((plugin, index) => index);
+
+    //Type: any
     await db.sortedSetAdd('plugins:active', order, defaultEnabled);
 }
 

--- a/src/install.js
+++ b/src/install.js
@@ -498,7 +498,7 @@ async function enableDefaultPlugins() {
         'nodebb-rewards-essentials',
         'nodebb-plugin-emoji',
         'nodebb-plugin-emoji-android',
-        'nodebb-plugin-dbsearch'
+        'nodebb-plugin-dbsearch',
     ];
     let customDefaults = nconf.get('defaultplugins') || nconf.get('defaultPlugins');
 

--- a/src/install.js
+++ b/src/install.js
@@ -491,7 +491,7 @@ async function createWelcomePost() {
 async function enableDefaultPlugins() {
     console.log('Enabling default plugins');
 
-    //Type: string[]
+    // Type: string[]
     let defaultEnabled = [
         'nodebb-plugin-composer-default',
         'nodebb-plugin-markdown',
@@ -503,10 +503,10 @@ async function enableDefaultPlugins() {
         'nodebb-plugin-dbsearch',
     ];
 
-    //Type: string[].
+    // Type: string[].
     let customDefaults = nconf.get('defaultplugins') || nconf.get('defaultPlugins');
 
-    //Type: none.
+    // Type: none.
     winston.info(`[install/defaultPlugins] customDefaults ${String(customDefaults)}`);
 
     if (customDefaults && customDefaults.length) {
@@ -523,13 +523,13 @@ async function enableDefaultPlugins() {
 
     winston.info('[install/enableDefaultPlugins] activating default plugins', defaultEnabled);
 
-    //Type: any
+    // Type: any
     const db = require('./database');
 
-    //Type: number[]
+    // Type: number[]
     const order = defaultEnabled.map((plugin, index) => index);
 
-    //Type: any
+    // Type: any
     await db.sortedSetAdd('plugins:active', order, defaultEnabled);
 }
 


### PR DESCRIPTION
The dbsearch plugin should now be automatically enabled upon setup, which allows for an already-present plugin to be used freely in this project. Resolves #2. 