### PR TITLE
Add button to allow users to make posts anonymous. 

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -63,8 +63,9 @@ define('forum/topic/postTools', [
 
     PostTools.toggle = function (pid, isDeleted) {
         const postEl = components.get('post', 'pid', pid);
+        console.log("toggle");
 
-        postEl.find('[component="post/quote"], [component="post/bookmark"], [component="post/reply"], [component="post/flag"], [component="user/chat"]')
+        postEl.find('[component="post/quote"], [component="post/bookmark"], [component="post/anonymous"], [component="post/reply"], [component="post/flag"], [component="user/chat"]')
             .toggleClass('hidden', isDeleted);
 
         postEl.find('[component="post/delete"]').toggleClass('hidden', isDeleted).parent().attr('hidden', isDeleted ? '' : null);
@@ -113,10 +114,34 @@ define('forum/topic/postTools', [
         });
 
         postContainer.on('click', '[component="post/bookmark"]', function () {
+            console.log("Click post/bookmark");
+
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
+        postContainer.on('click', '[component="post/anonymous"]', function () {
+            console.log("postContainer");
+
+
+            var textSpan = $(this).find('.anonymous-text');
+            // Toggle the text
+            if (textSpan.text() === "Anonymize") {
+                textSpan.text("Unanonymize");
+            } else {
+                textSpan.text("Anonymize");
+            }
+        
+            // return toggleAnonymous($(this), getData($(this), 'data-pid'));
+            var iconOff = $(this).find('[component="post/anonymous/off"]');
+            var iconOn = $(this).find('[component="post/anonymous/on"]');
+            
+            // Toggle the visibility of the icons
+            iconOff.toggleClass('hidden');
+            iconOn.toggleClass('hidden');
+        });
+
         postContainer.on('click', '[component="post/upvote"]', function () {
+            console.log("upvote");
             return votes.toggleVote($(this), '.upvoted', 1);
         });
 
@@ -352,6 +377,7 @@ define('forum/topic/postTools', [
     }
 
     function bookmarkPost(button, pid) {
+        console.log("bookmarkPost");
         const method = button.attr('data-bookmarked') === 'false' ? 'put' : 'del';
 
         api[method](`/posts/${pid}/bookmark`, undefined, function (err) {
@@ -363,6 +389,26 @@ define('forum/topic/postTools', [
         });
         return false;
     }
+
+    function toggleAnonymous(button, pid) {
+        console.log("toggleAnonymous");
+
+        const method = button.attr('data-anonymized') === 'false' ? 'put' : 'del';
+
+        console.log(method);
+        
+        api[method](`/posts/${pid}/anonymous`, undefined, function (err) {
+            if (err) {
+                console.log("if err");
+                // return alerts.error(err);
+            }
+            const type = method === 'put' ? 'setAnonymous' : 'unsetAnonymous';
+            hooks.fire(`action:post.${type}`, { pid: pid });
+            console.log("hooks.fire");
+        });
+        return false;
+    }
+    
 
     function getData(button, data) {
         return button.parents('[data-pid]').attr(data);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -114,32 +114,37 @@ define('forum/topic/postTools', [
         });
 
         postContainer.on('click', '[component="post/bookmark"]', function () {
-            console.log("Click post/bookmark");
-
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
-
+        //Used ChatGPT to help write code
         postContainer.on('click', '[component="post/anonymous"]', function () {
-            console.log("postContainer");
-
-
+            // Find the text span element within the clicked button
             var textSpan = $(this).find('.anonymous-text');
+            
             // Toggle the text
             if (textSpan.text() === "Anonymize") {
                 textSpan.text("Unanonymize");
+                // Update the username to "Anonymous"
+                $('[itemprop="author"]').text("Anonymous");
             } else {
                 textSpan.text("Anonymize");
+                // Update the username back to the actual username
+                var actualUsername = $('[itemprop="author"]').data("username");
+                $('[itemprop="author"]').text(actualUsername);
             }
         
-            // return toggleAnonymous($(this), getData($(this), 'data-pid'));
+            // Find the icons within the clicked button
             var iconOff = $(this).find('[component="post/anonymous/off"]');
             var iconOn = $(this).find('[component="post/anonymous/on"]');
             
             // Toggle the visibility of the icons
             iconOff.toggleClass('hidden');
             iconOn.toggleClass('hidden');
+            
+            // Prevent the default link behavior
+            return false;
         });
-
+        
         postContainer.on('click', '[component="post/upvote"]', function () {
             console.log("upvote");
             return votes.toggleVote($(this), '.upvoted', 1);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -122,7 +122,7 @@ define('forum/topic/postTools', [
          */
         postContainer.on('click', '[component="post/anonymous"]', function (event) {
             console.assert(event instanceof jQuery.Event, 'Invalid event parameter');
-            return anonymizePost($(this));
+            return anonymizePost($(this), getData($(this), 'data-pid'));
         });
 
         postContainer.on('click', '[component="post/upvote"]', function () {
@@ -361,20 +361,41 @@ define('forum/topic/postTools', [
     }
 
     // Used ChatGPT to help write code and type annotations
-    function anonymizePost(button) {
+    // Initialize a variable to store the original username link as an HTML string
+    var originalUsernameLink;
+
+    // Wait for the document to be ready before storing the link
+    $(document).ready(function() {
+        originalUsernameLink = $('[itemprop="author"]').prop('outerHTML');
+    });
+
+    function anonymizePost(button, pid) {
+        console.log(originalUsernameLink);
         // Find the text span element within the clicked button
         var textSpan = button.find('.anonymous-text');
         console.assert(textSpan instanceof jQuery, 'Invalid textSpan type');
 
+        // Extract the existing username and data-uid
+        const usernameRegex = /data-username="([^"]+)"/;
+        const uidRegex = /data-uid="([^"]+)"/;
+        const usernameMatch = originalUsernameLink.match(usernameRegex);
+        const uidMatch = originalUsernameLink.match(uidRegex);
+        const existingUsername = usernameMatch ? usernameMatch[1] : '';
+        const existingUid = uidMatch ? uidMatch[1] : '';
+
+        // Create the modified string
+        const modifiedUsernameLink = `<a itemprop="author" data-username=${existingUsername} data-uid="${existingUid}">Anonymous</a>`;
+
+        console.log(modifiedUsernameLink);
+
         // Toggle the text
         if (textSpan.text() === 'Anonymize') {
             textSpan.text('Unanonymize');
-            $('[itemprop="author"]').text('Anonymous');
+            $('[itemprop="author"]').replaceWith(modifiedUsernameLink); // Replace the link with plain text
         } else {
             textSpan.text('Anonymize');
-            var actualUsername = $('[itemprop="author"]').data('username');
-            console.assert(typeof actualUsername === 'string', 'Invalid actualUsername type');
-            $('[itemprop="author"]').text(actualUsername);
+            // Restore the original username link
+            $('[itemprop="author"]').replaceWith(originalUsernameLink);
         }
 
         // Find the icons within the clicked button
@@ -385,12 +406,12 @@ define('forum/topic/postTools', [
         // Toggle the visibility of the icons
         iconOff.toggleClass('hidden');
         iconOn.toggleClass('hidden');
-        return false;
+        return false
     }
 
     function bookmarkPost(button, pid) {
         const method = button.attr('data-bookmarked') === 'false' ? 'put' : 'del';
-
+        console.log("bookmark method = " + method);
         api[method](`/posts/${pid}/bookmark`, undefined, function (err) {
             if (err) {
                 return alerts.error(err);
@@ -398,6 +419,7 @@ define('forum/topic/postTools', [
             const type = method === 'put' ? 'bookmark' : 'unbookmark';
             hooks.fire(`action:post.${type}`, { pid: pid });
         });
+
         return false;
     }
 

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -374,7 +374,6 @@ define('forum/topic/postTools', [
             textSpan.text('Anonymize');
             var actualUsername = $('[itemprop="author"]').data('username');
             console.assert(typeof actualUsername === 'string', 'Invalid actualUsername type');
-            console.log('2')
             $('[itemprop="author"]').text(actualUsername);
         }
 

--- a/src/views/partials/fontawesome.tpl
+++ b/src/views/partials/fontawesome.tpl
@@ -731,6 +731,8 @@
         <i class="fa fa-usb"></i>
         <i class="fa fa-usd"></i>
         <i class="fa fa-user"></i>
+        ### {# Icon for anonymous toggle. #}
+        <i class="fa fa-user-alt-slash"></i>
         <i class="fa fa-user-circle"></i>
         <i class="fa fa-user-circle-o"></i>
         <i class="fa fa-user-md"></i>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -83,6 +83,16 @@
             <span component="post/bookmark-count" class="bookmarkCount badge" data-bookmarks="{posts.bookmarks}">{posts.bookmarks}</span>&nbsp;
         </a>
     </li>
+
+    <li>
+        <a component="post/anonymous" role="menuitem" tabindex="-1" href="#" data-anonymized="{posts.anonymized}">
+            <span class="menu-icon">
+                <i component="post/anonymous/off" class="fa fa-fw fa-user <!-- IF !posts.anonymized -->hidden<!-- ENDIF !posts.anonymized -->"></i>
+                <i component="post/anonymous/on" class="fa fa-fw fa-user-secret <!-- IF posts.anonymized -->hidden<!-- ENDIF posts.anonymized -->"></i>
+            </span>
+            <span class="anonymous-text">[[topic:Anonymize]]</span>
+        </a>
+    </li>
     {{{ end }}}
 
     <li>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -83,7 +83,8 @@
             <span component="post/bookmark-count" class="bookmarkCount badge" data-bookmarks="{posts.bookmarks}">{posts.bookmarks}</span>&nbsp;
         </a>
     </li>
-
+    {{{ end }}}
+<!-- IF posts.display_moderator_tools -->
     <li>
         <a component="post/anonymous" role="menuitem" tabindex="-1" href="#" data-anonymized="{posts.anonymized}">
             <span class="menu-icon">
@@ -93,7 +94,7 @@
             <span class="anonymous-text">[[topic:Anonymize]]</span>
         </a>
     </li>
-    {{{ end }}}
+<!-- END -->
 
     <li>
         <a role="menuitem" tabindex="-1" href="#" data-clipboard-text="{posts.absolute_url}">

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -83,8 +83,7 @@
             <span component="post/bookmark-count" class="bookmarkCount badge" data-bookmarks="{posts.bookmarks}">{posts.bookmarks}</span>&nbsp;
         </a>
     </li>
-    {{{ end }}}
-<!-- IF posts.display_moderator_tools -->
+
     <li>
         <a component="post/anonymous" role="menuitem" tabindex="-1" href="#" data-anonymized="{posts.anonymized}">
             <span class="menu-icon">
@@ -94,7 +93,7 @@
             <span class="anonymous-text">[[topic:Anonymize]]</span>
         </a>
     </li>
-<!-- END -->
+    {{{ end }}}
 
     <li>
         <a role="menuitem" tabindex="-1" href="#" data-clipboard-text="{posts.absolute_url}">


### PR DESCRIPTION
Modified themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl to add a button to the posts dropdown page. Added unique icons for anonymizing posts. 

Created an event listener in public/src/client/topic/postTools.js to handle click inputs from the button. The button changes the poster's username to "Anonymous" locally and toggles the button. Resolves #4.

Further changes need to be made so that the changes are made server-side instead of locally so that other users will be unable to see the username. Additionally, the user hyperlink will need to be removed/added back when anonymizing. 

Demo:
(Before)
![image](https://github.com/CMU-313/spring24-nodebb-purple_pizzazz/assets/115967184/19490145-cda9-4291-afa3-6c2e2ab9fd70)

(After)
![image](https://github.com/CMU-313/spring24-nodebb-purple_pizzazz/assets/115967184/171047ed-0760-46d0-a3b8-a04e17115bcc)
