### PR TITLE
Adding sonarqube-scanner tool

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
-        "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
+        "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha && npx sonarqube-scanner",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
     },
@@ -126,6 +126,7 @@
         "slideout": "1.0.1",
         "socket.io": "4.5.4",
         "socket.io-client": "4.5.4",
+        "sonarqube-scanner": "3.3.0",
         "sortablejs": "1.15.0",
         "spdx-license-list": "6.6.0",
         "spider-detector": "2.0.0",
@@ -172,6 +173,7 @@
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
         "smtp-server": "3.11.0",
+        "sonarqube-scanner": "3.3.0",
         "typescript": "^4.9.4"
     },
     "resolutions": {


### PR DESCRIPTION
I am attempting to add this tool to the project in this branch, due to concerns that DeepCode might not fit the needs for this project.

Using this tool requires one to have set up a server, which I could not set up in the time left. Still, I thought best to include this here.